### PR TITLE
Use self-contained executable for watermark utility

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Jira Issue Link(s)
+_Please provide a link to the Jira Issue(s) that this Pull Request resolves_
+
+## What does this PR change?
+_Please provide a short description of what the goal/purpose of this Pull Request is
+as well as links to any documentation that lives outside of the source code that has
+been updated as part of these changes_
+
+## TODO
+_List any remaining TODO items; useful when the Pull Request is opened as a draft/WIP_
+
+## Known Issues
+_List any issues that will not be resolved in this Pull Request and should be turned
+into Jira Issues_
+
+## Requirements for Reviewer
+- [ ] Are the parts of the code that are complex documented?
+- [ ] Has any other supplemental documentation been updated?
+- [ ] Does the code have automated tests?
+- [ ] Does the code follow agreed upon code conventions?

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,6 +29,7 @@ steps:
     command: 'build'
     projects: 'watermark-utility\WatermarkUtility.csproj'
     arguments: '--configuration $(buildConfiguration)'
+  condition: succeeded()
 
 - task: DotNetCoreCLI@2
   displayName: 'Run Watermark Utility Tests'
@@ -36,6 +37,7 @@ steps:
     command: 'test'
     projects: 'watermark-utility-tests\WatermarkUtilityTests.csproj'
     arguments: '--configuration $(buildConfiguration) --collect "Code coverage"'
+  condition: succeeded()
 
 - task: DotNetCoreCLI@2
   displayName: 'Package Watermark Utility'
@@ -46,9 +48,11 @@ steps:
     arguments: '--configuration $(BuildConfiguration) --self-contained true --runtime win10-x64 --output $(Build.ArtifactStagingDirectory)/Output'
     zipAfterPublish: true
     modifyOutputPath: true
+  condition: succeeded()
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Watermark Utility to Pipelines'
   inputs:
     pathtoPublish: '$(Build.ArtifactStagingDirectory)/Output'
     artifactName: 'watermark-utility-$(tag)'
+  condition: succeeded()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ steps:
     command: 'publish'
     publishWebProjects: false
     projects: 'watermark-utility\WatermarkUtility.csproj'
-    arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)/Output'
+    arguments: '--configuration $(BuildConfiguration) --self-contained true --runtime win10-x64 --output $(Build.ArtifactStagingDirectory)/Output'
     zipAfterPublish: true
     modifyOutputPath: true
 


### PR DESCRIPTION
## What does this implement?
- adds GitHub PR Template
- adds conditions to pipelines steps to show failure earlier
- changes the packaging of the watermark utility to use self-contained for Windows 10 X64
    - Without this, you would have to make sure that the correct version of .net was installed and available to run the watermark utility