### PR TITLE
Decrease encryption strength so pypdf2 can decrypt files

### DIFF
--- a/watermark-utility/Watermarker.cs
+++ b/watermark-utility/Watermarker.cs
@@ -114,7 +114,9 @@ namespace watermark_utility
                         null, // no user password
                         Encoding.UTF8.GetBytes(outputPassword), // set owner password
                         EncryptionConstants.ALLOW_PRINTING | EncryptionConstants.ALLOW_SCREENREADERS,
-                        EncryptionConstants.ENCRYPTION_AES_128 | EncryptionConstants.DO_NOT_ENCRYPT_METADATA
+                        // not all PDF utilities can deal with encryption that is stronger than STANDARD_ENCRYPTION_40 so
+                        // change this at your own risk!
+                        EncryptionConstants.STANDARD_ENCRYPTION_40 | EncryptionConstants.DO_NOT_ENCRYPT_METADATA
                     );
                     writer = new PdfWriter(output, writerProperties);
                 }


### PR DESCRIPTION
## Jira Issue Link(s)
**N/A**

## What does this PR change?
- decreases the encryption strength used when adding an owner password so that utilities like pypdf2 can decrypt the pdf

## TODO
**N/A**

## Known Issues
**N/A**

## Requirements for Reviewer
- [ ] Are the parts of the code that are complex documented?
- [ ] Has any other supplemental documentation been updated?
- [ ] Does the code have automated tests?
- [ ] Does the code follow agreed upon code conventions?
